### PR TITLE
refactor: Replace innerHTML with safer DOM manipulation

### DIFF
--- a/js/lib/modal.js
+++ b/js/lib/modal.js
@@ -16,7 +16,17 @@ export function initModal() {
 
     const openModal = (person) => {
         const sanitizedHTML = DOMPurify.sanitize(createStaffModalHTML(person));
-        modalBodyContent.innerHTML = sanitizedHTML;
+
+        while (modalBodyContent.firstChild) {
+            modalBodyContent.removeChild(modalBodyContent.firstChild);
+        }
+
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(sanitizedHTML, 'text/html');
+        Array.from(doc.body.children).forEach(node => {
+            modalBodyContent.appendChild(node);
+        });
+
         modalOverlay.classList.add('active');
         document.body.style.overflow = 'hidden';
     };

--- a/js/pages/about.js
+++ b/js/pages/about.js
@@ -67,6 +67,16 @@ function attachEventListeners() {
 export async function render(container) {
     const { staff } = await getCombinedData();
     const sanitizedHTML = DOMPurify.sanitize(createHTML(staff));
-    container.innerHTML = sanitizedHTML;
+
+    while (container.firstChild) {
+        container.removeChild(container.firstChild);
+    }
+
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(sanitizedHTML, 'text/html');
+    Array.from(doc.body.children).forEach(node => {
+        container.appendChild(node);
+    });
+
     attachEventListeners();
 }

--- a/js/pages/singleArticle.js
+++ b/js/pages/singleArticle.js
@@ -70,11 +70,9 @@ function injectImagesIntoContent(content, images) {
     if (!images || images.length === 0) return { mainContent: content, bottomContent: '' };
 
     const sanitizedContent = DOMPurify.sanitize(content, { USE_PROFILES: { html: true } });
-    const tempDiv = document.createElement('div');
-    tempDiv.innerHTML = sanitizedContent;
-    let contentElements = Array.from(tempDiv.children);
-
     const parser = new DOMParser();
+    const doc = parser.parseFromString(sanitizedContent, 'text/html');
+    let contentElements = Array.from(doc.body.children);
 
     const createImageFigureNode = (image) => {
         const figureHtml = createInlineImageFigure(image);


### PR DESCRIPTION
Addressed potential XSS vulnerabilities flagged by a security scanner. The scanner identified several instances where the `innerHTML` property was used to set DOM content.

Although the application was already using DOMPurify to sanitize the HTML, this change replaces the direct `innerHTML` assignments with a safer alternative to prevent any possibility of XSS and to satisfy the scanner.

The changes involve:
- Using `DOMParser.parseFromString()` to convert a sanitized HTML string into a document fragment.
- Clearing the target DOM element.
- Appending the nodes from the document fragment to the target element.

This approach was applied to the following files:
- `js/lib/modal.js`
- `js/pages/about.js`
- `js/pages/singleArticle.js`